### PR TITLE
Fixes to show tracking dashboard in admin

### DIFF
--- a/variome_backend/settings.py
+++ b/variome_backend/settings.py
@@ -91,6 +91,9 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # Application definition
 
 INSTALLED_APPS = [
+    "variome_backend",
+    "variome_backend.library",
+    "variome_backend.library_access",
     "pghistory.admin",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -104,9 +107,6 @@ INSTALLED_APPS = [
     "tracking",
     "pghistory",
     "pgtrigger",
-    "variome_backend",
-    "variome_backend.library",
-    "variome_backend.library_access",
 ]
 
 MIDDLEWARE = [

--- a/variome_backend/templates/admin/base.html
+++ b/variome_backend/templates/admin/base.html
@@ -55,7 +55,7 @@ This file is included so that we can show the link to the tracking dashboard in 
                 {% if frontend_url %}
                     <a href="{{ frontend_url }}">{% translate 'View site' %}</a> /
                 {% endif %}
-                <a href="/tracking">Tracking Dashboard</a> /
+                <a href="{% url "tracking_dashboard" %}">Tracking Dashboard</a> /
                 {% if user.is_active and user.is_staff %}
                     {% url 'django-admindocs-docroot' as docsroot %}
                     {% if docsroot %}


### PR DESCRIPTION
* Updated order of installed apps to prioritise overriden admin templates from variome_backend
* Use url tag to generate link to tracking dashboard. This will correctly prepend the URL_PREFIX value if set.