### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/variome_backend/library/views/variant.py
+++ b/variome_backend/library/views/variant.py
@@ -65,8 +65,8 @@ def variant(request, id):
         annotations = annotationsResult["annotations"]
         errors.append(annotationsResult["errors"])
 
-    except Exception as e:
-        errors.append(f"Error getting annotations: {e}")
+    except Exception:
+        errors.append("Error getting annotations")
 
     try:
         gnomadFrequenciesObject = GenomicGnomadFrequency.objects.get(


### PR DESCRIPTION
Potential fix for [https://github.com/wassermanlab/variome/security/code-scanning/1](https://github.com/wassermanlab/variome/security/code-scanning/1)

To fix this, keep detailed exception info out of the response and return only generic client-safe messages.  
Best approach here: replace `errors.append(f"Error getting annotations: {e}")` with a static message, while preserving behavior (the API still reports an annotation failure in `errors`).

In `variome_backend/library/views/variant.py`:
- Edit the `except Exception as e:` block around lines 68–70.
- Do **not** include `e` in the response message.
- Keep the rest of the response structure unchanged to avoid functional/API contract changes.

No new imports or dependencies are required for this minimal safe fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
